### PR TITLE
Update references to git repo

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -2,7 +2,7 @@ load("@bazel_gazelle//:def.bzl", "gazelle")
 load("@io_bazel_rules_go//go:def.bzl", "go_path", "nogo")
 load("@io_bazel_rules_docker//container:bundle.bzl", "container_bundle")
 
-# gazelle:prefix github.com/leoluk/NetMeta
+# gazelle:prefix github.com/monogon-dev/NetMeta
 # gazelle:exclude deploy
 # gazelle:exclude schema
 # gazelle:exclude third_party/tools

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ We will eventually provide pre-built images, for now, the build dependencies are
 Quick start:
 
 ```bash
-git clone https://github.com/leoluk/NetMeta && cd NetMeta
+git clone https://github.com/monogon-dev/NetMeta && cd NetMeta
 
 # Install dependencies
 ./install.sh

--- a/cmd/helloworld/BUILD
+++ b/cmd/helloworld/BUILD
@@ -4,7 +4,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 go_library(
     name = "go_default_library",
     srcs = ["helloworld.go"],
-    importpath = "github.com/leoluk/NetMeta/cmd/helloworld",
+    importpath = "github.com/monogon-dev/NetMeta/cmd/helloworld",
     visibility = ["//visibility:private"],
 )
 

--- a/cmd/risinfo/BUILD.bazel
+++ b/cmd/risinfo/BUILD.bazel
@@ -4,7 +4,7 @@ load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 go_library(
     name = "go_default_library",
     srcs = ["risinfo.go"],
-    importpath = "github.com/leoluk/NetMeta/cmd/risinfo",
+    importpath = "github.com/monogon-dev/NetMeta/cmd/risinfo",
     visibility = ["//visibility:private"],
     deps = [
         "@com_github_osrg_gobgp//pkg/packet/bgp:go_default_library",

--- a/deploy/cue.mod/module.cue
+++ b/deploy/cue.mod/module.cue
@@ -1,1 +1,1 @@
-module: "github.com/leoluk/NetMeta/deploy"
+module: "github.com/monogon-dev/NetMeta/deploy"

--- a/deploy/dashboards/netmeta_overview/NetMeta_Overview.cue
+++ b/deploy/dashboards/netmeta_overview/NetMeta_Overview.cue
@@ -326,7 +326,7 @@ panels: [{
 	id: 43
 	options: {
 		content: """
-			For questions, bug reports or feature requests please refer to https://github.com/leoluk/NetMeta or send a mail to netmeta@leoluk.de
+			For questions, bug reports or feature requests please refer to https://github.com/monogon-dev/NetMeta or send a mail to netmeta@leoluk.de
 
 			Contributions are very welcome!
 			"""

--- a/deploy/go.mod
+++ b/deploy/go.mod
@@ -1,4 +1,4 @@
-module github.com/leoluk/NetMeta/deploy
+module github.com/monogon-dev/NetMeta/deploy
 
 go 1.14
 

--- a/deploy/single-node/clickhouse/files.cue
+++ b/deploy/single-node/clickhouse/files.cue
@@ -298,7 +298,7 @@ k8s: clickhouseinstallations: netmeta: spec: configuration: files: {
     128	CWR
     """#
 
-	// TODO: deduplicate (https://github.com/leoluk/NetMeta/issues/6)
+	// TODO: deduplicate (https://github.com/monogon-dev/NetMeta/issues/6)
 	"FlowMessage.proto": #"""
       syntax = "proto3";
       package netmeta;

--- a/deploy/single-node/grafana/grafana.cue
+++ b/deploy/single-node/grafana/grafana.cue
@@ -9,8 +9,8 @@ import (
 	"strconv"
 
 	// Dashboards
-	dashboard_overview "github.com/leoluk/NetMeta/deploy/dashboards/netmeta_overview"
-	dashboard_queries "github.com/leoluk/NetMeta/deploy/dashboards/clickhouse_queries"
+	dashboard_overview "github.com/monogon-dev/NetMeta/deploy/dashboards/netmeta_overview"
+	dashboard_queries "github.com/monogon-dev/NetMeta/deploy/dashboards/clickhouse_queries"
 )
 
 // https://github.com/grafana/grafana/blob/master/docs/sources/administration/provisioning.md

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/leoluk/NetMeta
+module github.com/monogon-dev/NetMeta
 
 go 1.14
 

--- a/pb/BUILD.bazel
+++ b/pb/BUILD.bazel
@@ -10,7 +10,7 @@ proto_library(
 
 go_proto_library(
     name = "netmeta_go_proto",
-    importpath = "github.com/leoluk/NetMeta/pb",
+    importpath = "github.com/monogon-dev/NetMeta/pb",
     proto = ":netmeta_proto",
     visibility = ["//visibility:public"],
 )
@@ -18,6 +18,6 @@ go_proto_library(
 go_library(
     name = "go_default_library",
     embed = [":netmeta_go_proto"],
-    importpath = "github.com/leoluk/NetMeta/pb",
+    importpath = "github.com/monogon-dev/NetMeta/pb",
     visibility = ["//visibility:public"],
 )

--- a/third_party/tools/go.mod
+++ b/third_party/tools/go.mod
@@ -1,4 +1,4 @@
-module github.com/leoluk/NetMeta
+module github.com/monogon-dev/NetMeta
 
 go 1.14
 


### PR DESCRIPTION
I noticed the stale URL in README.md and while being at it I updated all other references to the old URL of the repo. I'm not experienced with the Go and Cue ecosystems, so tell me if this is a stupid idea. Everything (re)built and spun up fine here.